### PR TITLE
Tweaks to the pool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
-/src/test/
 /nb-configuration.xml
 country-details.json
 nbactions.xml
+.idea
+target/
+*.iml

--- a/pom.xml
+++ b/pom.xml
@@ -14,37 +14,9 @@
         </dependency>
         
         <dependency>
-            <groupId>com.hazelcast</groupId>
-            <artifactId>hazelcast-client</artifactId>
-            <version>3.12.1</version>
-            <type>jar</type>
-        </dependency>
-        
-        <dependency>
-            <groupId>net.bytebuddy</groupId>
-            <artifactId>byte-buddy</artifactId>
-            <version>1.7.1</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>3.8.1</version>
-            <scope>test</scope>
-            <type>jar</type>
-        </dependency>
-        <dependency>
-            <groupId>net.bytebuddy</groupId>
-            <artifactId>byte-buddy-agent</artifactId>
-            <version>1.10.7</version>
-            <type>jar</type>
-            <scope>test</scope>
-        </dependency>
-        
-        <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>5.0.2</version>
+            <version>8.0.19</version>
         </dependency>
 
         <dependency>
@@ -62,24 +34,20 @@
             <type>jar</type>
             <scope>compile</scope>
         </dependency>
+
         <dependency>
-            <groupId>org.apache.httpcomponents.client5</groupId>
-            <artifactId>httpclient5</artifactId>
-            <version>5.0-beta5</version>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13</version>
+            <scope>test</scope>
             <type>jar</type>
         </dependency>
         <dependency>
-            <groupId>com.google.code.gson</groupId>
-            <artifactId>gson</artifactId>
-            <version>2.8.5</version>
-            <type>jar</type>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>mysql</artifactId>
+            <version>1.13.0</version>
+            <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-            <version>3.1</version>
-            <type>jar</type>
-        </dependency>     
     </dependencies>
    
     

--- a/src/main/java/com/hazelcast/custom/ApachePool.java
+++ b/src/main/java/com/hazelcast/custom/ApachePool.java
@@ -1,0 +1,40 @@
+package com.hazelcast.custom;
+
+import org.apache.commons.dbcp.ConnectionFactory;
+import org.apache.commons.dbcp.DriverManagerConnectionFactory;
+import org.apache.commons.dbcp.PoolableConnectionFactory;
+import org.apache.commons.dbcp.PoolingDataSource;
+import org.apache.commons.pool.ObjectPool;
+import org.apache.commons.pool.impl.GenericObjectPool;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Properties;
+
+public final class ApachePool implements Pool {
+    private final PoolingDataSource poolingDataSource;
+
+    public ApachePool(Properties properties) {
+        GenericObjectPool.Config conPoolCfg = new GenericObjectPool.Config();
+        conPoolCfg.maxActive = 15;
+        conPoolCfg.maxIdle = 8;
+        conPoolCfg.maxWait = 60000;
+        conPoolCfg.minIdle = 2;
+
+        String JDBC_DB_URL = (String) properties.get("dburl");
+        String JDBC_USER = (String) properties.get("dbuser");
+        String JDBC_PASS = (String) properties.get("dbpass");
+
+        ConnectionFactory connectionFactory = new DriverManagerConnectionFactory(JDBC_DB_URL, JDBC_USER, JDBC_PASS);
+
+        ObjectPool connectionPool = new GenericObjectPool(null, conPoolCfg);
+        PoolableConnectionFactory poolableConnectionFactory = new PoolableConnectionFactory(connectionFactory, connectionPool, null, null, false, true);
+
+        poolingDataSource = new PoolingDataSource(connectionPool);
+    }
+
+    @Override
+    public Connection getConnection() throws SQLException {
+        return poolingDataSource.getConnection();
+    }
+}

--- a/src/main/java/com/hazelcast/custom/Client.java
+++ b/src/main/java/com/hazelcast/custom/Client.java
@@ -1,26 +1,26 @@
-package com.hazelcast.custom;
-
-import com.hazelcast.client.HazelcastClient;
-import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.IMap;
-
-/**
- *
- * @author Benjamin E Ndugga
- */
-public class Client {
-
-    public static void main(String[] args) {
-
-        //connnect to the HZ-Instance  
-        HazelcastInstance hazelcastInstance = HazelcastClient.newHazelcastClient();
-        IMap<Object, Object> map_country_codes = hazelcastInstance.getMap("country_codes");
-        map_country_codes.put("UGANDA", "UG");
-        map_country_codes.put("KENYA", "KE");
-        map_country_codes.put("TANZANIA", "TZ");
-       
-        hazelcastInstance.shutdown();
-
-    }
-
-}
+//package com.hazelcast.custom;
+//
+//import com.hazelcast.client.HazelcastClient;
+//import com.hazelcast.core.HazelcastInstance;
+//import com.hazelcast.core.IMap;
+//
+///**
+// *
+// * @author Benjamin E Ndugga
+// */
+//public class Client {
+//
+//    public static void main(String[] args) {
+//
+//        //connnect to the HZ-Instance
+//        HazelcastInstance hazelcastInstance = HazelcastClient.newHazelcastClient();
+//        IMap<Object, Object> map_country_codes = hazelcastInstance.getMap("country_codes");
+//        map_country_codes.put("UGANDA", "UG");
+//        map_country_codes.put("KENYA", "KE");
+//        map_country_codes.put("TANZANIA", "TZ");
+//
+//        hazelcastInstance.shutdown();
+//
+//    }
+//
+//}

--- a/src/main/java/com/hazelcast/custom/Pool.java
+++ b/src/main/java/com/hazelcast/custom/Pool.java
@@ -1,0 +1,8 @@
+package com.hazelcast.custom;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+public interface Pool {
+    Connection getConnection() throws SQLException;
+}

--- a/src/main/resources/hazelcast.xml
+++ b/src/main/resources/hazelcast.xml
@@ -5,103 +5,18 @@
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
            http://www.hazelcast.com/schema/config/hazelcast-config-3.12.xsd">
 
-    
-    <group>
-        <name>dev</name>
-        <password>dev-pass</password>
-    </group>
-    
-    <instance-name>hz-Instance1</instance-name>	
-
-    <properties>
-        <property name="hazelcast.slow.operation.detector.stacktrace.logging.enabled">true</property>
-        <property name="hazelcast.logging.type">jdk</property>
-        <property name="hazelcast.rest.enabled">true</property>
-        <property name="hazelcast.diagnostics.enabled">false</property>
-        <property name="hazelcast.diagnostics.metric.level">debug</property>
-        <property name="hazelcast.diagnostics.storeLatency.period.seconds">5</property>
-    </properties>
-
-    <management-center enabled="false">http://localhost:4848/mancenter</management-center>
-    <network>
-        <port auto-increment="true" port-count="100">5701</port>
-        <outbound-ports>
-            <!--
-            Allowed port range when connecting to other nodes.
-            0 or * means use system provided port.
-            -->
-            <ports>0</ports>
-        </outbound-ports>
-        <join>
-            <multicast enabled="false">
-                <multicast-group>224.2.2.3</multicast-group>
-                <multicast-port>54327</multicast-port>
-            </multicast>
-            <tcp-ip enabled="true">
-                <interface>localhost</interface>
-                <member-list>
-                    <member>localhost</member>
-                </member-list>
-            </tcp-ip>
-        </join>
-    </network>
-    
     <map name="capitals">
-        <in-memory-format>BINARY</in-memory-format>
-        <backup-count>1</backup-count>
-        <async-backup-count>0</async-backup-count>
-        <time-to-live-seconds>2592000</time-to-live-seconds>
-        <max-idle-seconds>2592000</max-idle-seconds>
-        <eviction-policy>LFU</eviction-policy>
-        <max-size policy="PER_NODE">150000</max-size>
-        <eviction-percentage>25</eviction-percentage>
-        <min-eviction-check-millis>100</min-eviction-check-millis>
-        <merge-policy>com.hazelcast.map.merge.PutIfAbsentMapMergePolicy</merge-policy>
-        <cache-deserialized-values>INDEX-ONLY</cache-deserialized-values>
-        <map-store enabled="true" initial-mode="LAZY">
+        <map-store initial-mode="EAGER">
             <class-name>com.hazelcast.custom.SQLBasedMapStore</class-name>
-            <write-delay-seconds>10</write-delay-seconds>
-            <write-batch-size>10</write-batch-size>
-            <write-coalescing>false</write-coalescing>
             <properties>
                 <property name="key">country</property>
                 <property name="value">capital</property>
                 <property name="dbdriver">com.mysql.jdbc.Driver</property>
                 <property name="dburl">jdbc:mysql://localhost:3306/mydb</property>
                 <property name="dbschema">mydb</property>
-                <property name="dbuser">root</property>
+                <property name="dbuser">hazelcast</property>
                 <property name="dbpass">pass123</property>
             </properties>
         </map-store>
     </map>
-    
-    <map name="country_codes">
-        <in-memory-format>BINARY</in-memory-format>
-        <backup-count>1</backup-count>
-        <async-backup-count>0</async-backup-count>
-        <time-to-live-seconds>2592000</time-to-live-seconds>
-        <max-idle-seconds>2592000</max-idle-seconds>
-        <eviction-policy>LFU</eviction-policy>
-        <max-size policy="PER_NODE">150000</max-size>
-        <eviction-percentage>25</eviction-percentage>
-        <min-eviction-check-millis>100</min-eviction-check-millis>
-        <merge-policy>com.hazelcast.map.merge.PutIfAbsentMapMergePolicy</merge-policy>
-        <cache-deserialized-values>INDEX-ONLY</cache-deserialized-values>
-        <map-store enabled="true" initial-mode="LAZY">
-            <class-name>com.hazelcast.custom.SQLBasedMapStore</class-name>
-            <write-delay-seconds>10</write-delay-seconds>
-            <write-batch-size>10</write-batch-size>
-            <write-coalescing>false</write-coalescing>
-            <properties>
-                <property name="key">country</property>
-                <property name="value">country_code</property>
-                <property name="dbdriver">com.mysql.jdbc.Driver</property>
-                <property name="dburl">jdbc:mysql://localhost:3306/mydb</property>
-                <property name="dbschema">mydb</property>
-                <property name="dbuser">root</property>
-                <property name="dbpass">pass123</property>
-            </properties>
-        </map-store>
-    </map>
-    <lite-member enabled="false"/>
 </hazelcast>

--- a/src/test/java/com/hazelcast/custom/ApachePoolTest.java
+++ b/src/test/java/com/hazelcast/custom/ApachePoolTest.java
@@ -1,0 +1,46 @@
+package com.hazelcast.custom;
+
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import org.junit.Rule;
+import org.junit.Test;
+import org.testcontainers.containers.MySQLContainer;
+
+import static org.junit.Assert.*;
+
+public class ApachePoolTest {
+
+    @Rule
+    public final MySQLContainer mysql = new MySQLContainer("mysql:5.5")
+            .withUsername("hazelcast")
+            .withPassword("pass123");
+
+    @Test
+    public void testMapStoreInstantiation() {
+        HazelcastInstance hazelcastInstance = Hazelcast.newHazelcastInstance();
+        IMap<Integer, String> map = hazelcastInstance.getMap("capitals");
+        map.put(0, "foo");
+
+        String s = map.get(0);
+        assertEquals("foo", s);
+    }
+
+    @Test
+    public void testStoreAndLoad() {
+        HazelcastInstance instance1 = Hazelcast.newHazelcastInstance();
+        IMap<Integer, String> map1 = instance1.getMap("capitals");
+        map1.put(0, "foo");
+        map1.flush();
+        instance1.shutdown();
+
+        // shutdown the first Hazelcast instance and start a new one.
+        // the new instance is using the same backing mysql store as the
+        // first one. Hence it should see the value inserted above.
+        HazelcastInstance instance2 = Hazelcast.newHazelcastInstance();
+        IMap<Integer, String> map2 = instance2.getMap("capitals");
+        String s = map2.get(0);
+        assertEquals("foo", s);
+    }
+
+}


### PR DESCRIPTION
Hello @benjamin-Ndugga,

I proposing some changes which should help you move forward with this work. 
List of my changes: 
1. remove hard dependency on Apache Pool impl
2. add junit skeleton
3. remove unnecessary configuration. it was just noise
4. removed .src/tests/  from .gitignore 

I recommend you to continue as following:
1. Make the test working - right now it's not passing. It's using the [TestContainers](https://www.testcontainers.org/modules/databases/mysql/) project to test against Mysql. It's currently failing with some authentication exception:

```
INFO: [172.24.0.1]:5701 [dev] [3.12.1] Initializing cluster partition table arrangement...
java.sql.SQLException: Access denied for user 'hazelcast'@'172.22.0.1' (using password: YES)
	at com.mysql.cj.jdbc.exceptions.SQLError.createSQLException(SQLError.java:129)
	at com.mysql.cj.jdbc.exceptions.SQLError.createSQLException(SQLError.java:97)
	at com.mysql.cj.jdbc.exceptions.SQLExceptionsMapping.translateException(SQLExceptionsMapping.java:122)
	at com.mysql.cj.jdbc.ConnectionImpl.createNewIO(ConnectionImpl.java:836)
	at com.mysql.cj.jdbc.ConnectionImpl.<init>(ConnectionImpl.java:456)
	at com.mysql.cj.jdbc.ConnectionImpl.getInstance(ConnectionImpl.java:246)
	at com.mysql.cj.jdbc.NonRegisteringDriver.connect(NonRegisteringDriver.java:197)
	at java.sql/java.sql.DriverManager.getConnection(DriverManager.java:677)
	at java.sql/java.sql.DriverManager.getConnection(DriverManager.java:228)
	at org.apache.commons.dbcp.DriverManagerConnectionFactory.createConnection(DriverManagerConnectionFactory.java:75)
	at org.apache.commons.dbcp.PoolableConnectionFactory.makeObject(PoolableConnectionFactory.java:582)
	at org.apache.commons.pool.impl.GenericObjectPool.borrowObject(GenericObjectPool.java:1148)
	at org.apache.commons.dbcp.PoolingDataSource.getConnection(PoolingDataSource.java:106)
	at com.hazelcast.custom.ApachePool.getConnection(ApachePool.java:38)
```

I know different versions of MySQL use different auth methods. Making this to work should be your top priority. When you have an automated test you can rely on it's much easier to do further changes. If you feel stuck I can have a look at this further. Just ping me on [Twitter](https://twitter.com/jerrinot/)


2. Clean-up the SQLBasedMapStore:
  - proper exception handling
  - proper resource cleaning
  - do not call System.exit(). never:)

3. write implementation for additional connection pools. right now the `SQLBasedMapStore` always creates an instance of `ApachePool`. However this could be configured via properties. 


Thank you for your work and feel free to ping me if you have any question! 
Jaromir Hamala